### PR TITLE
Provide an option to manage common firewall chains yourself

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,29 @@ If you need to override pod and/or service subnets for a PAM install, you'll als
         service_subnet => '10.48.1.0/24',
     }
 
+### Managing common firewall chains
+
+If you manage common firewall chains explicitly and purge unknown rules, such as
+
+    firewallchain {'OUTPUT:filter:IPv4']:
+        policy => 'drop',
+        purge  => true,
+    }
+
+you'll need to disable this module's management of those chains and ignore foreign rules to avoid
+deleting rules created by Kubernetes
+
+    include ::firewall
+    class {'::pam_firewall':
+        manage_common_chains => false,
+    }
+
+    firewallchain {'OUTPUT:filter:IPv4']:
+        policy         => 'drop',
+        purge          => true,
+        ignore_foreign => true
+    }
+
 [firewall]: https://forge.puppet.com/modules/puppetlabs/firewall
 [Standalone]: https://puppet.com/docs/continuous-delivery/4.x/pam/pam-node-arch.html
 [Bolt]: http://pup.pt/installbolt

--- a/spec/classes/pam_firewall_spec.rb
+++ b/spec/classes/pam_firewall_spec.rb
@@ -189,5 +189,20 @@ describe 'pam_firewall' do
         )
       }
     end
+
+    context 'without common firewallchains' do
+      let(:facts) { os_facts }
+      let(:params) { { 'manage_common_chains' => false } }
+
+      it { is_expected.not_to contain_firewallchain('INPUT:filter:IPv4') }
+      it { is_expected.not_to contain_firewallchain('OUTPUT:filter:IPv4') }
+      it { is_expected.not_to contain_firewallchain('FORWARD:filter:IPv4') }
+      it { is_expected.not_to contain_firewallchain('PREROUTING:nat:IPv4') }
+      it { is_expected.not_to contain_firewallchain('INPUT:nat:IPv4') }
+      it { is_expected.not_to contain_firewallchain('OUTPUT:nat:IPv4') }
+      it { is_expected.not_to contain_firewallchain('POSTROUTING:nat:IPv4') }
+      it { is_expected.not_to contain_firewallchain('PREROUTING:raw:IPv4') }
+      it { is_expected.not_to contain_firewallchain('OUTPUT:raw:IPv4') }
+    end
   end
 end


### PR DESCRIPTION
Puppet doesn't support declaring the same resource twice, even if the resource definitions look compatible. Provides an option to skip managing common chains if you plan to do so explicitly.