### PR TITLE
(maint) Adding another ipv6 chain for k8s 1.21

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -105,6 +105,7 @@ class pam_firewall (
     'KUBE-FORWARD:filter:IPv6',
     'KUBE-NODE-PORT:filter:IPv6',
     'KUBE-FIREWALL:filter:IPv6',
+    'KUBE-KUBELET-CANARY:filter:IPv6',
     'WEAVE:nat:IPv4' ]:
     ensure => present,
     purge  => false,


### PR DESCRIPTION
When deploying PAM 1.62.0 with k8s 1.21.8, numerous ipv6 chains are
built.  This array lists them out so they are not deleted.

This addresses the error observed in CI:

```
[2022-02-17T19:57:54.395Z]                     "  Firewallchain[KUBE-KUBELET-CANARY:filter:IPv6]: change from 'present' to 'absent' failed: Execution of '/usr/sbin/ip6tables -t filter -X KUBE-KUBELET-CANARY' returned 1: ip6tables: No chain/target/match by that name.",
```