### PR TITLE
(CDPE-5716) Update to support Flannel CNI

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -29,7 +29,7 @@ The following parameters are available in the `pam_firewall` class:
 
 Data type: `Array[String]`
 
-Nodes in a cluster that need access to etcd, weave, and kubelet.
+Nodes in a cluster that need access to etcd, weave/flannel, and kubelet.
 Default works for Standalone architectures.
 
 Default value: `[$::ipaddress]`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,7 +2,7 @@
 # Puppet-supported Kubernetes.
 #
 # @param cluster_nodes
-#   Nodes in a cluster that need access to etcd, weave, and kubelet.
+#   Nodes in a cluster that need access to etcd, weave/flannel, and kubelet.
 #   Default works for Standalone architectures.
 #
 # @param app_ports
@@ -68,17 +68,36 @@ class pam_firewall (
     'DOCKER:filter:IPv4',
     'DOCKER:nat:IPv4',
     'KUBE-FIREWALL:filter:IPv4',
+    'KUBE-FIREWALL:filter:IPv6',
     'KUBE-FIREWALL:nat:IPv4',
+    'KUBE-FIREWALL:nat:IPv6',
     'KUBE-FORWARD:filter:IPv4',
+    'KUBE-FORWARD:filter:IPv6',
+    'KUBE-IPVS-FILTER:filter:IPv4',
+    'KUBE-IPVS-FILTER:filter:IPv6',
     'KUBE-KUBELET-CANARY:filter:IPv4',
+    'KUBE-KUBELET-CANARY:filter:IPv6',
     'KUBE-KUBELET-CANARY:mangle:IPv4',
     'KUBE-KUBELET-CANARY:nat:IPv4',
     'KUBE-LOAD-BALANCER:nat:IPv4',
+    'KUBE-LOAD-BALANCER:nat:IPv6',
     'KUBE-MARK-DROP:nat:IPv4',
+    'KUBE-MARK-DROP:nat:IPv6',
     'KUBE-MARK-MASQ:nat:IPv4',
+    'KUBE-MARK-MASQ:nat:IPv6',
+    'KUBE-NODE-PORT:filter:IPv4',
+    'KUBE-NODE-PORT:filter:IPv6',
     'KUBE-NODE-PORT:nat:IPv4',
+    'KUBE-NODE-PORT:nat:IPv6',
     'KUBE-POSTROUTING:nat:IPv4',
+    'KUBE-POSTROUTING:nat:IPv6',
+    'KUBE-PROXY-FIREWALL:filter:IPv4',
+    'KUBE-PROXY-FIREWALL:filter:IPv6',
     'KUBE-SERVICES:nat:IPv4',
+    'KUBE-SERVICES:nat:IPv6',
+    'KUBE-SOURCE-RANGES-FIREWALL:filter:IPv4',
+    'KUBE-SOURCE-RANGES-FIREWALL:filter:IPv6',
+    # Weave chains
     'WEAVE-CANARY:filter:IPv4',
     'WEAVE-CANARY:mangle:IPv4',
     'WEAVE-CANARY:nat:IPv4',
@@ -94,25 +113,10 @@ class pam_firewall (
     'WEAVE-NPC-EGRESS:filter:IPv4',
     'WEAVE-NPC-INGRESS:filter:IPv4',
     'WEAVE-NPC:filter:IPv4',
-    'KUBE-NODE-PORT:filter:IPv4',
-    'KUBE-MARK-DROP:nat:IPv6',
-    'KUBE-SERVICES:nat:IPv6',
-    'KUBE-POSTROUTING:nat:IPv6',
-    'KUBE-FIREWALL:nat:IPv6',
-    'KUBE-NODE-PORT:nat:IPv6',
-    'KUBE-LOAD-BALANCER:nat:IPv6',
-    'KUBE-MARK-MASQ:nat:IPv6',
-    'KUBE-FORWARD:filter:IPv6',
-    'KUBE-NODE-PORT:filter:IPv6',
-    'KUBE-FIREWALL:filter:IPv6',
-    'KUBE-KUBELET-CANARY:filter:IPv6',
     'WEAVE:nat:IPv4',
-    'KUBE-PROXY-FIREWALL:filter:IPv4',
-    'KUBE-SOURCE-RANGES-FIREWALL:filter:IPv4',
-    'KUBE-IPVS-FILTER:filter:IPv4',
-    'KUBE-PROXY-FIREWALL:filter:IPv6',
-    'KUBE-SOURCE-RANGES-FIREWALL:filter:IPv6',
-    'KUBE-IPVS-FILTER:filter:IPv6',
+    # Flannel chains
+    'FLANNEL-FWD:filter:IPv4',
+    'FLANNEL-POSTRTG:nat:IPv4',
     ]:
     ensure => present,
     purge  => false,
@@ -147,6 +151,14 @@ class pam_firewall (
       source => $node,
       dport  => [2379, 2380],
       proto  => 'tcp',
+      action => 'accept',
+    }
+
+    firewall { "110 allow udp port 8472 from ${node} for Flannel":
+      ensure => present,
+      source => $node,
+      dport  => 8472,
+      proto  => 'udp',
       action => 'accept',
     }
 

--- a/spec/classes/pam_firewall_spec.rb
+++ b/spec/classes/pam_firewall_spec.rb
@@ -30,6 +30,16 @@ describe 'pam_firewall' do
       }
 
       it {
+        is_expected.to contain_firewall('110 allow udp port 8472 from 172.16.254.254 for Flannel').with(
+          'ensure' => 'present',
+          'source' => '172.16.254.254',
+          'dport'  => 8_472,
+          'proto'  => 'udp',
+          'action' => 'accept',
+        )
+      }
+
+      it {
         is_expected.to contain_firewall('110 allow tcp port 6783 from 172.16.254.254 for Weave').with(
           'ensure' => 'present',
           'source' => '172.16.254.254',
@@ -77,6 +87,16 @@ describe 'pam_firewall' do
       }
 
       it {
+        is_expected.to contain_firewall('110 allow udp port 8472 from 172.16.0.0 for Flannel').with(
+          'ensure' => 'present',
+          'source' => '172.16.0.0',
+          'dport'  => 8_472,
+          'proto'  => 'udp',
+          'action' => 'accept',
+        )
+      }
+
+      it {
         is_expected.to contain_firewall('110 allow tcp port 6783 from 172.16.0.0 for Weave').with(
           'ensure' => 'present',
           'source' => '172.16.0.0',
@@ -112,6 +132,16 @@ describe 'pam_firewall' do
           'source' => '172.16.0.1',
           'dport'  => [2_379, 2_380],
           'proto'  => 'tcp',
+          'action' => 'accept',
+        )
+      }
+
+      it {
+        is_expected.to contain_firewall('110 allow udp port 8472 from 172.16.0.1 for Flannel').with(
+          'ensure' => 'present',
+          'source' => '172.16.0.1',
+          'dport'  => 8_472,
+          'proto'  => 'udp',
           'action' => 'accept',
         )
       }


### PR DESCRIPTION
Puppet Application Manager is migrating from Weave to Flannel.  This commit updates the pam_firewall module to include the Flannel chains and ports.

During the time where customers will be split between PAM releases on weave and others on flannel, this module will need to support both.  This is why the weave chains and rules have been left behind.

The port specified is to align with the documentation at https://kurl.sh/docs/add-ons/flannel.  The chain names are from manual installation, checking the chains created.  They are defined in https://github.com/flannel-io/flannel/blob/v0.21.5/main.go#L357 and https://github.com/flannel-io/flannel/blob/v0.21.5/main.go#L408.

The diff is a bit messy because I sorted the chains to make it easy to spot and remove duplicates now and going forward.

Testing was done manually.  Used this version of the module to set up iptables for both standalone and HA PAM clusters running weave and upgraded them to flannel.