### PR TITLE
(CDPE-5425) Updating rules for k8s 1.26

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -106,7 +106,14 @@ class pam_firewall (
     'KUBE-NODE-PORT:filter:IPv6',
     'KUBE-FIREWALL:filter:IPv6',
     'KUBE-KUBELET-CANARY:filter:IPv6',
-    'WEAVE:nat:IPv4' ]:
+    'WEAVE:nat:IPv4',
+    'KUBE-PROXY-FIREWALL:filter:IPv4',
+    'KUBE-SOURCE-RANGES-FIREWALL:filter:IPv4',
+    'KUBE-IPVS-FILTER:filter:IPv4',
+    'KUBE-PROXY-FIREWALL:filter:IPv6',
+    'KUBE-SOURCE-RANGES-FIREWALL:filter:IPv6',
+    'KUBE-IPVS-FILTER:filter:IPv6',
+    ]:
     ensure => present,
     purge  => false,
   }


### PR DESCRIPTION
K8s 1.25 and 1.26 introduce a handful of new iptables chains that pam_firewall needs to take into account. This commit adds those rules to the list to not purge.