### PR TITLE
(maint) Updating module for firewall 7.0.0 changes

### DIFF
--- a/examples/init.pp
+++ b/examples/init.pp
@@ -1,23 +1,23 @@
 include ::firewall
 
 firewall { '000 accept all icmp':
-  proto  => 'icmp',
-  action => 'accept',
+  proto => 'icmp',
+  jump  => 'accept',
 }
 -> firewall { '001 accept all to lo interface':
   proto   => 'all',
   iniface => 'lo',
-  action  => 'accept',
+  jump    => 'accept',
 }
 -> firewall { '002 accept related established rules':
-  proto  => 'all',
-  state  => ['RELATED', 'ESTABLISHED'],
-  action => 'accept',
+  proto => 'all',
+  state => ['RELATED', 'ESTABLISHED'],
+  jump  => 'accept',
 }
 -> firewall { '003 accept inbound SSH':
-  dport  => 22,
-  proto  => 'tcp',
-  action => 'accept',
+  dport => 22,
+  proto => 'tcp',
+  jump  => 'accept',
 }
 
 Firewallchain {
@@ -31,7 +31,7 @@ resources { 'firewallchain':
 include ::pam_firewall
 
 firewall { '899 drop broadcast':
-  action   => 'drop',
+  jump     => 'drop',
   dst_type => 'BROADCAST',
   proto    => 'all',
 }
@@ -45,6 +45,6 @@ firewall { '900 INPUT denies get logged':
 }
 
 firewall { '999 drop all':
-  proto  => 'all',
-  action => 'drop',
+  proto => 'all',
+  jump  => 'drop',
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -127,21 +127,21 @@ class pam_firewall (
     ensure => present,
     dport  => 8800,
     proto  => 'tcp',
-    action => 'accept',
+    jump   => 'accept',
   }
 
   firewall { '110 allow tcp app ports':
     ensure => present,
     dport  => $app_ports,
     proto  => 'tcp',
-    action => 'accept',
+    jump   => 'accept',
   }
 
   firewall { '110 allow tcp port 6443 for Kubernetes API':
     ensure => present,
     dport  => 6443,
     proto  => 'tcp',
-    action => 'accept',
+    jump   => 'accept',
   }
 
   # Rules for intra-cluster communication
@@ -151,7 +151,7 @@ class pam_firewall (
       source => $node,
       dport  => [2379, 2380],
       proto  => 'tcp',
-      action => 'accept',
+      jump   => 'accept',
     }
 
     firewall { "110 allow udp port 8472 from ${node} for Flannel":
@@ -159,7 +159,7 @@ class pam_firewall (
       source => $node,
       dport  => 8472,
       proto  => 'udp',
-      action => 'accept',
+      jump   => 'accept',
     }
 
     firewall { "110 allow tcp port 6783 from ${node} for Weave":
@@ -167,7 +167,7 @@ class pam_firewall (
       source => $node,
       dport  => 6783,
       proto  => 'tcp',
-      action => 'accept',
+      jump   => 'accept',
     }
 
     firewall { "110 allow udp ports 6783-6784 from ${node} for Weave":
@@ -175,7 +175,7 @@ class pam_firewall (
       source => $node,
       dport  => [6783, 6784],
       proto  => 'udp',
-      action => 'accept',
+      jump   => 'accept',
     }
 
     firewall { "110 allow tcp port 10250 from ${node} for Kubelet":
@@ -183,7 +183,7 @@ class pam_firewall (
       source => $node,
       dport  => 10250,
       proto  => 'tcp',
-      action => 'accept',
+      jump   => 'accept',
     }
   }
 
@@ -192,13 +192,13 @@ class pam_firewall (
     ensure => present,
     source => $pod_subnet,
     proto  => 'all',
-    action => 'accept',
+    jump   => 'accept',
   }
 
   firewall { '110 allow service network':
     ensure => present,
     source => $service_subnet,
     proto  => 'all',
-    action => 'accept',
+    jump   => 'accept',
   }
 }

--- a/spec/classes/pam_firewall_spec.rb
+++ b/spec/classes/pam_firewall_spec.rb
@@ -25,7 +25,7 @@ describe 'pam_firewall' do
           'source' => '172.16.254.254',
           'dport'  => [2_379, 2_380],
           'proto'  => 'tcp',
-          'action' => 'accept',
+          'jump'   => 'accept',
         )
       }
 
@@ -35,7 +35,7 @@ describe 'pam_firewall' do
           'source' => '172.16.254.254',
           'dport'  => 8_472,
           'proto'  => 'udp',
-          'action' => 'accept',
+          'jump'   => 'accept',
         )
       }
 
@@ -45,7 +45,7 @@ describe 'pam_firewall' do
           'source' => '172.16.254.254',
           'dport'  => 6_783,
           'proto'  => 'tcp',
-          'action' => 'accept',
+          'jump'   => 'accept',
         )
       }
 
@@ -55,7 +55,7 @@ describe 'pam_firewall' do
           'source' => '172.16.254.254',
           'dport'  => [6_783, 6_784],
           'proto'  => 'udp',
-          'action' => 'accept',
+          'jump'   => 'accept',
         )
       }
 
@@ -65,7 +65,7 @@ describe 'pam_firewall' do
           'source' => '172.16.254.254',
           'dport'  => 10_250,
           'proto'  => 'tcp',
-          'action' => 'accept',
+          'jump'   => 'accept',
         )
       }
     end
@@ -82,7 +82,7 @@ describe 'pam_firewall' do
           'source' => '172.16.0.0',
           'dport'  => [2_379, 2_380],
           'proto'  => 'tcp',
-          'action' => 'accept',
+          'jump'   => 'accept',
         )
       }
 
@@ -92,7 +92,7 @@ describe 'pam_firewall' do
           'source' => '172.16.0.0',
           'dport'  => 8_472,
           'proto'  => 'udp',
-          'action' => 'accept',
+          'jump'   => 'accept',
         )
       }
 
@@ -102,7 +102,7 @@ describe 'pam_firewall' do
           'source' => '172.16.0.0',
           'dport'  => 6_783,
           'proto'  => 'tcp',
-          'action' => 'accept',
+          'jump'   => 'accept',
         )
       }
 
@@ -112,7 +112,7 @@ describe 'pam_firewall' do
           'source' => '172.16.0.0',
           'dport'  => [6_783, 6_784],
           'proto'  => 'udp',
-          'action' => 'accept',
+          'jump'   => 'accept',
         )
       }
 
@@ -122,7 +122,7 @@ describe 'pam_firewall' do
           'source' => '172.16.0.0',
           'dport'  => 10_250,
           'proto'  => 'tcp',
-          'action' => 'accept',
+          'jump'   => 'accept',
         )
       }
 
@@ -132,7 +132,7 @@ describe 'pam_firewall' do
           'source' => '172.16.0.1',
           'dport'  => [2_379, 2_380],
           'proto'  => 'tcp',
-          'action' => 'accept',
+          'jump'   => 'accept',
         )
       }
 
@@ -142,7 +142,7 @@ describe 'pam_firewall' do
           'source' => '172.16.0.1',
           'dport'  => 8_472,
           'proto'  => 'udp',
-          'action' => 'accept',
+          'jump'   => 'accept',
         )
       }
 
@@ -152,7 +152,7 @@ describe 'pam_firewall' do
           'source' => '172.16.0.1',
           'dport'  => 6_783,
           'proto'  => 'tcp',
-          'action' => 'accept',
+          'jump'   => 'accept',
         )
       }
 
@@ -162,7 +162,7 @@ describe 'pam_firewall' do
           'source' => '172.16.0.1',
           'dport'  => [6_783, 6_784],
           'proto'  => 'udp',
-          'action' => 'accept',
+          'jump'   => 'accept',
         )
       }
 
@@ -172,7 +172,7 @@ describe 'pam_firewall' do
           'source' => '172.16.0.1',
           'dport'  => 10_250,
           'proto'  => 'tcp',
-          'action' => 'accept',
+          'jump'   => 'accept',
         )
       }
     end
@@ -187,7 +187,7 @@ describe 'pam_firewall' do
           'ensure' => 'present',
           'dport'  => [443],
           'proto'  => 'tcp',
-          'action' => 'accept',
+          'jump'   => 'accept',
         )
       }
     end
@@ -207,7 +207,7 @@ describe 'pam_firewall' do
           'ensure' => 'present',
           'source' => '10.48.0.0/24',
           'proto'  => 'all',
-          'action' => 'accept',
+          'jump'   => 'accept',
         )
       }
       it {
@@ -215,7 +215,7 @@ describe 'pam_firewall' do
           'ensure' => 'present',
           'source' => '10.48.1.0/24',
           'proto'  => 'all',
-          'action' => 'accept',
+          'jump'   => 'accept',
         )
       }
     end


### PR DESCRIPTION
The "action" resource attribute has been removed in firewall 7.0.0 (https://forge.puppet.com/modules/puppetlabs/firewall/readme#migration-path-to-v700). This commit updates pam_firewall to swap them out for the suggested "jump" attribute.