### PR TITLE
(CDPE-7033,CDPE-7026) Updating chains for PAM 1.112.4 and remove legacy fact

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,4 +4,6 @@
 fixtures:
   forge_modules:
     stdlib: "puppetlabs/stdlib"
-    firewall: "puppetlabs/firewall"
+    firewall:
+     repo: "puppetlabs/firewall"
+     ref: "3.6.0"

--- a/Puppetfile
+++ b/Puppetfile
@@ -4,5 +4,5 @@
 # The following directive installs modules to the managed moduledir.
 moduledir '.modules'
 
-mod 'puppetlabs/firewall', '3.1.0'
+mod 'puppetlabs/firewall', '3.6.0'
 mod 'puppetlabs/stdlib', '7.1.0'

--- a/bolt-project.yaml
+++ b/bolt-project.yaml
@@ -1,4 +1,5 @@
 ---
 name: pam_firewall
 modules:
-- puppetlabs/firewall
+- name: puppetlabs/firewall
+  version_requirement: '3.6.0'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -75,6 +75,8 @@ class pam_firewall (
     'KUBE-FORWARD:filter:IPv6',
     'KUBE-IPVS-FILTER:filter:IPv4',
     'KUBE-IPVS-FILTER:filter:IPv6',
+    'KUBE-IPVS-OUT-FILTER:filter:IPv4',
+    'KUBE-IPVS-OUT-FILTER:filter:IPv6',
     'KUBE-KUBELET-CANARY:filter:IPv4',
     'KUBE-KUBELET-CANARY:filter:IPv6',
     'KUBE-KUBELET-CANARY:mangle:IPv4',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,7 +24,7 @@
 #   this to false; if you purge unknown firewall rules, set `ignore_foreign=true`
 #   on these chains so Kubernetes rules aren't removed.
 class pam_firewall (
-  Array[String] $cluster_nodes = [$::ipaddress],
+  Array[String] $cluster_nodes = [$facts['networking']['ip']],
   Array[Variant[String, Integer]] $app_ports = [80, 443, 8000, 9001],
   String $pod_subnet = '10.32.0.0/22',
   String $service_subnet = '10.96.0.0/22',

--- a/spec/default_facts.yml
+++ b/spec/default_facts.yml
@@ -2,7 +2,9 @@
 #
 # Facts specified here will override the values provided by rspec-puppet-facts.
 ---
-ipaddress: "172.16.254.254"
-ipaddress6: "FE80:0000:0000:0000:AAAA:AAAA:AAAA"
+networking:
+  ip: "172.16.254.254"
+  ip6: "FE80:0000:0000:0000:AAAA:AAAA:AAAA"
+  mac: "AA:AA:AA:AA:AA:AA"
 is_pe: false
 macaddress: "AA:AA:AA:AA:AA:AA"


### PR DESCRIPTION
This PR includes a couple fixes for the next release of the pam_firewall module.  

First is a commit that adds an additional chain introduced in the move to k8s 1.30 in PAM 1.112.4.  This new chain was added to k8s 1.29 by https://github.com/kubernetes/kubernetes/commit/62683c8d9595f6791549cd887334b5e75f414175.

Second, a commit to remove a reference to the legacy ipaddress fact.

In order to avoid an upstream bug in puppetlabs/firewall, this PR also includes a pin of the module to 3.6.0, a known working version.